### PR TITLE
Use typeof for ViewPropTypes

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -58,7 +58,7 @@ export interface RatingProps {
   /**
    * Exposes style prop to add additonal styling to the container view
    */
-  style?: ViewPropTypes.style;
+  style?: typeof ViewPropTypes.style;
 
   /**
    * Whether the rating can be modiefied by the user


### PR DESCRIPTION
`ViewPropTypes` in `@types/react-native` is a `const`, so it cannot be used here without `typeof`