### PR TITLE
feat: add types for tintColor and size

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -42,6 +42,11 @@ export interface RatingProps {
   ratingTextColor?: string;
 
   /**
+   * Color used for the background
+   */
+  tintColor?: string;
+
+  /**
    * The size of each rating image
    *
    * Default is 50
@@ -123,6 +128,14 @@ export interface AirbnbRatingProps {
    * Default is 5
    */
   count?: number;
+
+  /**
+   * Size of rating image
+   *
+   * Default is 40
+   */
+  size?: number;
+
 
   /**
    * Determines if to show the reviews above the rating

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -136,6 +136,13 @@ export interface AirbnbRatingProps {
    */
   size?: number;
 
+  /**
+   * Whether the rating can be modiefied by the user
+   *
+   * Default is false
+   */
+  isDisabled?: boolean;
+
 
   /**
    * Determines if to show the reviews above the rating


### PR DESCRIPTION
There were some missing types in `d.ts`, so I've added them