### PR TITLE
add "starStyle" props

### DIFF
--- a/src/components/Star.js
+++ b/src/components/Star.js
@@ -38,7 +38,7 @@ export default class Star extends PureComponent {
   }
 
   render() {
-    const { fill, size, selectedColor, isDisabled } = this.props;
+    const { fill, size, selectedColor, isDisabled, starStyle } = this.props;
     const starSource = fill && selectedColor === null ? STAR_SELECTED_IMAGE : STAR_IMAGE;
 
     return (
@@ -52,7 +52,8 @@ export default class Star extends PureComponent {
               width: size || STAR_SIZE,
               height: size || STAR_SIZE,
               transform: [{ scale: this.springValue }]
-            }
+            },
+            starStyle
           ]}
         />
       </TouchableOpacity>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -132,6 +132,13 @@ export interface AirbnbRatingProps {
   showRating?: boolean;
 
   /**
+   * Style for star image component
+   *
+   * Default is true
+   */
+  starStyle?: ImageStyle;
+
+  /**
    * Callback method when the user finishes rating. Gives you the final rating value as a whole number
    */
   onFinishRating?( value: number ): void;


### PR DESCRIPTION
resolve https://github.com/Monte9/react-native-ratings/issues/53

## What
Able to pass "startStyle" prop, it is useful if we want to customize style of `Star` component. Especially space between stars.