### PR TITLE
Fix #37. Remove unexpected console statements

### DIFF
--- a/src/SwipeRating.js
+++ b/src/SwipeRating.js
@@ -45,7 +45,6 @@ export default class SwipeRating extends Component {
     ratingBackgroundColor: 'white',
     ratingCount: 5,
     imageSize: 40,
-    onFinishRating: () => console.log('Attach a onFinishRating function here.'),
     minValue: 0
   };
 
@@ -73,7 +72,7 @@ export default class SwipeRating extends Component {
             // 'round up' to the nearest rating image
             this.setCurrentRating(rating);
           }
-          onFinishRating(rating);
+          if (typeof onFinishRating === 'function') onFinishRating(rating);
         }
       }
     });

--- a/src/TapRating.js
+++ b/src/TapRating.js
@@ -12,7 +12,6 @@ export default class TapRating extends Component {
     defaultRating: 3,
     reviews: ["Terrible", "Bad", "Okay", "Good", "Great"],
     count: 5,
-    onFinishRating: () => console.log('Rating selected. Attach a function here.'),
     showRating: true,
     reviewColor: 'rgba(230, 196, 46, 1)',
     reviewSize: 25
@@ -47,7 +46,7 @@ export default class TapRating extends Component {
   starSelectedInPosition(position) {
     const { onFinishRating } = this.props
 
-    onFinishRating(position);
+    if (typeof onFinishRating === 'function') onFinishRating(position);
 
     this.setState({ position: position })
   }


### PR DESCRIPTION
The reason for that is I think that it is not necessary to use console statements in production code. Also, `onFinishRating` callback is described in the [API](https://github.com/Monte9/react-native-ratings#api) section in docs.

Related to issue #37 