### PR TITLE
react-native-web fix deprecated proptypes

### DIFF
--- a/src/SwipeRating.js
+++ b/src/SwipeRating.js
@@ -329,7 +329,7 @@ const fractionsType = (props, propName, componentName) => {
 
 SwipeRating.propTypes = {
   type: PropTypes.string,
-  ratingImage: Image.propTypes.source,
+  ratingImage: Image.propTypes ? Image.propTypes.source : PropTypes.any,
   ratingColor: PropTypes.string,
   ratingBackgroundColor: PropTypes.string,
   ratingCount: PropTypes.number,
@@ -338,7 +338,7 @@ SwipeRating.propTypes = {
   onStartRating: PropTypes.func,
   onFinishRating: PropTypes.func,
   showRating: PropTypes.bool,
-  style: ViewPropTypes.style,
+  style: ViewPropTypes ? ViewPropTypes.style : PropTypes.any,
   readonly: PropTypes.bool,
   showReadOnlyText: PropTypes.bool,
   startingValue: PropTypes.number,


### PR DESCRIPTION
The proptypes for view and image have been removed entirely from react-native-web so throw an error now when attempting to use this component

See the reasoning [here](https://github.com/necolas/react-native-web/releases/tag/0.12.0)