### PR TITLE
AirbnbRating Custom Images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 .DS_Store
 *.log
 yarn-error.log
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Install the package using yarn or npm:
 import { Rating, AirbnbRating } from 'react-native-ratings';
 
 const WATER_IMAGE = require('./water.png')
+const WATER_IMAGE_FILLED = require('./water_filled.png')
 
 ratingCompleted(rating) {
   console.log("Rating is: " + rating)
@@ -59,6 +60,8 @@ ratingCompleted(rating) {
   reviews={["Terrible", "Bad", "Meh", "OK", "Good", "Hmm...", "Very Good", "Wow", "Amazing", "Unbelievable", "Jesus"]}
   defaultRating={11}
   size={20}
+  image={WATER_IMAGE}
+  selectedImage={WATER_IMAGE_FILLED}
 />
 
 <Rating
@@ -105,6 +108,8 @@ Also refer to the [`example`](https://github.com/Monte9/react-native-ratings/tre
 | isDisabled | false | boolean | Whether the rating can be modiefied by the user |
 | onFinishRating | none | function(value: number) | Callback method when the user finishes rating. Gives you the final rating value as a whole number |
 | starContainerStyle | none | object or stylesheet | Custom styles applied to the star container |
+| image | none | image source | Image to be displayed as the unfilled rating icon |
+| selectedImage | none | image source | Image to be displayed as the filled rating icon |
 
 ### RatingProps
 

--- a/src/components/Star.js
+++ b/src/components/Star.js
@@ -7,7 +7,10 @@ const STAR_SIZE = 40;
 
 export default class Star extends PureComponent {
   static defaultProps = {
-    selectedColor: '#f1c40f'
+    selectedColor: '#f1c40f',
+    size: STAR_SIZE,
+    image: STAR_IMAGE,
+    selectedImage: STAR_SELECTED_IMAGE
   };
 
   constructor() {
@@ -38,8 +41,8 @@ export default class Star extends PureComponent {
   }
 
   render() {
-    const { fill, size, selectedColor, isDisabled, starStyle } = this.props;
-    const starSource = fill && selectedColor === null ? STAR_SELECTED_IMAGE : STAR_IMAGE;
+    const { fill, size, selectedColor, isDisabled, starStyle, image, selectedImage } = this.props;
+    const starSource = fill ? selectedImage : image;
 
     return (
       <TouchableOpacity activeOpacity={1} onPress={this.spring.bind( this )} disabled={isDisabled}>
@@ -49,8 +52,8 @@ export default class Star extends PureComponent {
             styles.starStyle,
             {
               tintColor: fill && selectedColor ? selectedColor : undefined,
-              width: size || STAR_SIZE,
-              height: size || STAR_SIZE,
+              width: size,
+              height: size,
               transform: [{ scale: this.springValue }]
             },
             starStyle

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -159,6 +159,20 @@ export interface AirbnbRatingProps {
   starStyle?: ImageStyle;
 
   /**
+   * Inactive image for star component
+   *
+   * Default is undefined (use built-in star)
+   */
+  image?: ImageURISource;
+
+  /**
+   * Active image for star component
+   *
+   * Default is undefined (use built-in star)
+   */
+  selectedImage?: ImageURISource;
+
+  /**
    * Callback method when the user finishes rating. Gives you the final rating value as a whole number
    */
   onFinishRating?( value: number ): void;


### PR DESCRIPTION
Allow for custom images (like in `Rating`) in the `AirbnbRating` component.
- Custom images for the unselected and selected icons can be passed into
  `TapRating` (`AirbnbRating`) (affects `Star` component)
- Selected images will be tinted with the selected color, unless unspecified
- Minor cleanups (eg. set size default in defaultProps instead of doing a check in render)

I wrote this as I wanted tap-based ratings with a custom image in my app, but it didn't seem to be possible before. Tested on iOS. 