### PR TITLE
remove React-Native PropTypes

### DIFF
--- a/src/SwipeRating.js
+++ b/src/SwipeRating.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 
 import {
   View, Text, Animated, PanResponder, Image,
-  StyleSheet, Platform, ViewPropTypes
+  StyleSheet, Platform
 } from 'react-native';
 
 // RATING IMAGES WITH STATIC BACKGROUND COLOR (white)
@@ -329,7 +329,7 @@ const fractionsType = (props, propName, componentName) => {
 
 SwipeRating.propTypes = {
   type: PropTypes.string,
-  ratingImage: Image.propTypes.source,
+  ratingImage: PropTypes.object,
   ratingColor: PropTypes.string,
   ratingBackgroundColor: PropTypes.string,
   ratingCount: PropTypes.number,
@@ -338,7 +338,7 @@ SwipeRating.propTypes = {
   onStartRating: PropTypes.func,
   onFinishRating: PropTypes.func,
   showRating: PropTypes.bool,
-  style: ViewPropTypes.style,
+  style: PropTypes.object,
   readonly: PropTypes.bool,
   showReadOnlyText: PropTypes.bool,
   startingValue: PropTypes.number,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { ImageStyle, ImageURISource, ViewPropTypes } from 'react-native';
+import PropTypes from 'prop-types';
+import { ImageStyle, ImageURISource } from 'react-native';
 
 export interface RatingProps {
 
@@ -63,7 +64,7 @@ export interface RatingProps {
   /**
    * Exposes style prop to add additonal styling to the container view
    */
-  style?: typeof ViewPropTypes.style;
+  style?: typeof PropTypes.object;
 
   /**
    * Whether the rating can be modiefied by the user


### PR DESCRIPTION
Deprecated in RN 62 and removed from RN-web 12, should be removed to maintain compatability.