### PR TITLE
fix: swipe, isComponentMounted state issue

### DIFF
--- a/src/SwipeRating.js
+++ b/src/SwipeRating.js
@@ -90,7 +90,7 @@ export default class SwipeRating extends Component {
       const ROCKET_IMAGE = await require('./images/rocket.png');
       const BELL_IMAGE = await require('./images/bell.png');
 
-      this.setState({ display: true, isComponentMounted: false });
+      this.setState({ display: true, isComponentMounted: true });
     } catch(err) {
       console.log(err)
     }


### PR DESCRIPTION
Bug: Swipe was broken due to incorrect state being set on componentMounting.