### PR TITLE
Extend properties in index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -163,6 +163,13 @@ export interface AirbnbRatingProps {
    * Callback method when the user finishes rating. Gives you the final rating value as a whole number
    */
   onFinishRating?( value: number ): void;
+  
+  /**
+   * Color value for filled stars.
+   *
+   * Default is #004666
+   */
+  selectedColor?: string;
 }
 
 export class AirbnbRating extends React.Component<AirbnbRatingProps> {}


### PR DESCRIPTION
Currently the use of selectedColor is possible in typescript but cause some error.

 Property 'selectedColor' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<AirbnbRating> & Readonly<AirbnbRatingProps> & Readonly<...>'.