### PR TITLE
TapRating Unselected Icon Tint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 .DS_Store
 *.log
 yarn-error.log
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Also refer to the [`example`](https://github.com/Monte9/react-native-ratings/tre
 | reviews | ['Terrible', 'Bad', 'Okay', 'Good', 'Great'] | string[] | Labels to show when each value is tapped e.g. If the first star is tapped, then value in index 0 will be used as the label |
 | count | 5 | number | Total number of ratings to display |
 | selectedColor | #f1c40f | string (color) | Pass in a custom fill-color for the rating icon |
+| unselectedColor | #000000 | string (color) | Pass in a custom fill-color for the unselected rating icon |
 | reviewColor | #f1c40f | string (color) | Pass in a custom text color for the review text |
 | reviewSize | 25 | number | Pass in a custom font size for the review text |
 | showRating | `true` | boolean | Determines if to show the reviews above the rating |

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Install the package using yarn or npm:
 import { Rating, AirbnbRating } from 'react-native-ratings';
 
 const WATER_IMAGE = require('./water.png')
+const WATER_IMAGE_FILLED = require('./water_filled.png')
 
 ratingCompleted(rating) {
   console.log("Rating is: " + rating)
@@ -59,6 +60,8 @@ ratingCompleted(rating) {
   reviews={["Terrible", "Bad", "Meh", "OK", "Good", "Hmm...", "Very Good", "Wow", "Amazing", "Unbelievable", "Jesus"]}
   defaultRating={11}
   size={20}
+  image={WATER_IMAGE}
+  selectedImage={WATER_IMAGE_FILLED}
 />
 
 <Rating
@@ -105,6 +108,8 @@ Also refer to the [`example`](https://github.com/Monte9/react-native-ratings/tre
 | isDisabled | false | boolean | Whether the rating can be modiefied by the user |
 | onFinishRating | none | function(value: number) | Callback method when the user finishes rating. Gives you the final rating value as a whole number |
 | starContainerStyle | none | object or stylesheet | Custom styles applied to the star container |
+| image | none | image source | Image to be displayed as the unfilled rating icon |
+| selectedImage | none | image source | Image to be displayed as the filled rating icon |
 
 ### RatingProps
 

--- a/src/components/Star.js
+++ b/src/components/Star.js
@@ -7,7 +7,10 @@ const STAR_SIZE = 40;
 
 export default class Star extends PureComponent {
   static defaultProps = {
-    selectedColor: '#f1c40f'
+    selectedColor: '#f1c40f',
+    size: STAR_SIZE,
+    image: STAR_IMAGE,
+    selectedImage: STAR_SELECTED_IMAGE
   };
 
   constructor() {
@@ -38,8 +41,8 @@ export default class Star extends PureComponent {
   }
 
   render() {
-    const { fill, size, selectedColor, isDisabled, starStyle } = this.props;
-    const starSource = fill && selectedColor === null ? STAR_SELECTED_IMAGE : STAR_IMAGE;
+    const { fill, size, selectedColor, isDisabled, starStyle, image, selectedImage } = this.props;
+    const starSource = fill ? selectedImage : image;
 
     return (
       <TouchableOpacity activeOpacity={1} onPress={this.spring.bind( this )} disabled={isDisabled}>
@@ -49,8 +52,8 @@ export default class Star extends PureComponent {
             styles.starStyle,
             {
               tintColor: fill && selectedColor ? selectedColor : undefined,
-              width: size || STAR_SIZE,
-              height: size || STAR_SIZE,
+              width: size,
+              height: size,
               transform: [{ scale: this.springValue }]
             },
             starStyle

--- a/src/components/Star.js
+++ b/src/components/Star.js
@@ -8,6 +8,7 @@ const STAR_SIZE = 40;
 export default class Star extends PureComponent {
   static defaultProps = {
     selectedColor: '#f1c40f',
+    unselectedColor: '#000000',
     size: STAR_SIZE,
     image: STAR_IMAGE,
     selectedImage: STAR_SELECTED_IMAGE
@@ -41,8 +42,13 @@ export default class Star extends PureComponent {
   }
 
   render() {
-    const { fill, size, selectedColor, isDisabled, starStyle, image, selectedImage } = this.props;
+    const { fill, size, selectedColor, unselectedColor, isDisabled, starStyle, image, selectedImage } = this.props;
     const starSource = fill ? selectedImage : image;
+    let tint = undefined;
+    if (fill && selectedColor)
+      tint = selectedColor;
+    else if (!fill && unselectedColor)
+      tint = unselectedColor;
 
     return (
       <TouchableOpacity activeOpacity={1} onPress={this.spring.bind( this )} disabled={isDisabled}>
@@ -51,7 +57,7 @@ export default class Star extends PureComponent {
           style={[
             styles.starStyle,
             {
-              tintColor: fill && selectedColor ? selectedColor : undefined,
+              tintColor: tint,
               width: size,
               height: size,
               transform: [{ scale: this.springValue }]

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -173,6 +173,27 @@ export interface AirbnbRatingProps {
   selectedImage?: ImageURISource;
 
   /**
+   * Pass in a custom text color for the review text
+   *
+   * Default is '#f1c40f'
+   */
+  reviewColor?: string;
+
+  /**
+   * Pass in a custom tint-color for the rating icon when selected
+   *
+   * Default is '#f1c40f'
+   */
+  selectedColor?: string;
+
+  /**
+   * Pass in a custom tint-color for the rating icon when unselected
+   *
+   * Default is '#000000'
+   */
+  unselectedColor?: string;
+
+  /**
    * Callback method when the user finishes rating. Gives you the final rating value as a whole number
    */
   onFinishRating?( value: number ): void;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -159,6 +159,20 @@ export interface AirbnbRatingProps {
   starStyle?: ImageStyle;
 
   /**
+   * Inactive image for star component
+   *
+   * Default is undefined (use built-in star)
+   */
+  image?: ImageURISource;
+
+  /**
+   * Active image for star component
+   *
+   * Default is undefined (use built-in star)
+   */
+  selectedImage?: ImageURISource;
+
+  /**
    * Callback method when the user finishes rating. Gives you the final rating value as a whole number
    */
   onFinishRating?( value: number ): void;


### PR DESCRIPTION
This PR adds the option for tinting the unselected TapRating image. My personal use-case was to change the outline color to adapt to dark mode when applicable.

It also looks like my other contribution (#90) for allowing custom TapRating images, which was previously merged, has somehow been wiped from master. That change is in this branch as well, but if that change was intentionally removed I can modify this PR to not include it.