### PR TITLE
Custom Color for AirbnbRating unfilled rating star

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Also refer to the [`example`](https://github.com/Monte9/react-native-ratings/tre
 | reviews | ['Terrible', 'Bad', 'Okay', 'Good', 'Great'] | string[] | Labels to show when each value is tapped e.g. If the first star is tapped, then value in index 0 will be used as the label |
 | count | 5 | number | Total number of ratings to display |
 | selectedColor | #f1c40f | string (color) | Pass in a custom fill-color for the rating icon |
+| unSelectedColor | #BDC3C7 | string (color) | Pass in a custom not fill-color for the rating icon |
 | reviewColor | #f1c40f | string (color) | Pass in a custom text color for the review text |
 | reviewSize | 25 | number | Pass in a custom font size for the review text |
 | showRating | `true` | boolean | Determines if to show the reviews above the rating |

--- a/src/components/Star.js
+++ b/src/components/Star.js
@@ -7,7 +7,8 @@ const STAR_SIZE = 40;
 
 export default class Star extends PureComponent {
   static defaultProps = {
-    selectedColor: '#f1c40f'
+    selectedColor: '#f1c40f',
+    unSelectedColor: "#BDC3C7",
   };
 
   constructor() {
@@ -39,7 +40,7 @@ export default class Star extends PureComponent {
   }
 
   render() {
-    const { fill, size, selectedColor, isDisabled, starStyle } = this.props;
+    const { fill, size, selectedColor,unSelectedColor, isDisabled, starStyle } = this.props;
     const starSource = fill && selectedColor === null ? STAR_SELECTED_IMAGE : STAR_IMAGE;
 
     return (
@@ -49,7 +50,7 @@ export default class Star extends PureComponent {
           style={[
             styles.starStyle,
             {
-              tintColor: fill && selectedColor ? selectedColor : undefined,
+              tintColor: fill && selectedColor ? selectedColor : unSelectedColor,
               width: size || STAR_SIZE,
               height: size || STAR_SIZE,
               transform: [{ scale: this.springValue }]

--- a/src/components/Star.js
+++ b/src/components/Star.js
@@ -40,7 +40,7 @@ export default class Star extends PureComponent {
   }
 
   render() {
-    const { fill, size, selectedColor,unSelectedColor, isDisabled, starStyle } = this.props;
+    const { fill, size, selectedColor, unSelectedColor, isDisabled, starStyle } = this.props;
     const starSource = fill && selectedColor === null ? STAR_SELECTED_IMAGE : STAR_IMAGE;
 
     return (

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -170,6 +170,13 @@ export interface AirbnbRatingProps {
    * Default is #004666
    */
   selectedColor?: string;
+  
+    /**
+   * Color value for unfilled stars.
+   *
+   * Default is #BDC3C7
+   */
+  unSelectedColor?: string;
 }
 
 export class AirbnbRating extends React.Component<AirbnbRatingProps> {}


### PR DESCRIPTION
pass the unSelectedColor props to star to use for custom color for AirbnbRating unfilled rating star. It's also fixed the unfilled rating star bug in Android which I faced during down-grading the rating in Android (unfilled star will not shown after down-grading).