### PR TITLE
Update Star.js

### DIFF
--- a/src/components/Star.js
+++ b/src/components/Star.js
@@ -49,7 +49,7 @@ export default class Star extends PureComponent {
           style={[
             styles.starStyle,
             {
-              tintColor: fill && selectedColor ? selectedColor : undefined,
+              tintColor: fill && selectedColor ? selectedColor : '#e5e5e5',
               width: size || STAR_SIZE,
               height: size || STAR_SIZE,
               transform: [{ scale: this.springValue }]


### PR DESCRIPTION
It will solve the issue where deselected stars change into white color in Airbnb Ratings.

Solves these reported issues: 
#131 , #126 , #125 