### PR TITLE
Fix SwipeRating to start at the tapped point + Add jumpValue and onSwipeRating props, tap to rate feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ Also refer to the [`example`](https://github.com/Monte9/react-native-ratings/tre
 | fractions | 2 | number | The number of decimal places for the rating value; must be between 0 and 20 |
 | minValue | 0 | number | The minimum value the user can select |
 | style | none | style | Exposes style prop to add additonal styling to the container view (optional) |
-| onStartRating | none | function | Callback method when the user starts rating |
+| jumpValue | 0 | number | The value to jump when rating value changes (if `jumpValue` === 0.5, rating value increases/decreases like 0, 0.5, 1.0, 1.5 ...). Default is 0 (not to jump)|
+| onStartRating | none | function(rating: number) | Callback method when the user starts rating. Gives you the start rating value as a whole number |
+| onSwipeRating | none | function(rating: number) | Callback method when the user is swiping. Gives you the current rating value as a whole number|
 | onFinishRating | none | function(rating: number) | Callback method when the user finishes rating. Gives you the final rating value as a whole number (required) |
 
 ## Try it out

--- a/src/SwipeRating.js
+++ b/src/SwipeRating.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import {
   View, Text, Animated, PanResponder, Image,
-  StyleSheet, Platform
+  StyleSheet, Platform, Dimensions
 } from 'react-native';
 
 // RATING IMAGES WITH STATIC BACKGROUND COLOR (white)
@@ -45,26 +45,35 @@ export default class SwipeRating extends Component {
     ratingCount: 5,
     showReadOnlyText: true,
     imageSize: 40,
-    minValue: 0
+    minValue: 0,
+    jumpValue: 0,
   };
 
   constructor(props) {
     super(props);
-    const { onStartRating, onFinishRating, fractions } = this.props;
+    const { onStartRating, onSwipeRating, onFinishRating, fractions } = this.props;
     const position = new Animated.ValueXY();
 
     const panResponder = PanResponder.create({
       onStartShouldSetPanResponder: () => true,
-      onPanResponderGrant: () => {
-        if (typeof onStartRating === 'function') {
-          onStartRating();
+      onPanResponderGrant: (event, gesture) => {
+        const newPosition = new Animated.ValueXY();
+        const tapPositionX = gesture.x0 - this.state.centerX + gesture.dx;
+        newPosition.setValue({ x: tapPositionX, y: 0 });
+        if (this.state.isComponentMounted) {
+          this.setState({ position: newPosition, value: tapPositionX });
+          const rating = this.getCurrentRating(tapPositionX);
+          if (typeof onStartRating === 'function') onStartRating(rating);
         }
       },
       onPanResponderMove: (event, gesture) => {
         const newPosition = new Animated.ValueXY();
-        newPosition.setValue({ x: gesture.dx, y: 0 });
+        const tapPositionX = gesture.x0 - this.state.centerX + gesture.dx;
+        newPosition.setValue({ x: tapPositionX, y: 0 });
         if (this.state.isComponentMounted) {
-          this.setState({position: newPosition, value: gesture.dx});
+          this.setState({ position: newPosition, value: tapPositionX });
+          const rating = this.getCurrentRating(tapPositionX);
+          if (typeof onSwipeRating === "function") onSwipeRating(rating);
         }
       },
       onPanResponderRelease: event => {
@@ -101,6 +110,14 @@ export default class SwipeRating extends Component {
     if (this.props.startingValue !== prevProps.startingValue) {
       this.setCurrentRating(this.props.startingValue);
     }
+  }
+
+  handleLayoutChange() {
+    this.ratingRef.measure((fx, fy, width, height, px, py) => {
+      this.setState({
+        centerX: (px % Dimensions.get("window").width) + width / 2,
+      });
+    });
   }
 
   getPrimaryViewStyle() {
@@ -179,8 +196,17 @@ export default class SwipeRating extends Component {
     } else {
       currentRating = !fractions ? Math.ceil(startingValue) : +startingValue.toFixed(fractions);
     }
-
-    return currentRating;
+    if (
+      this.props.jumpValue > 0 &&
+      this.props.jumpValue < this.props.ratingCount
+    ) {
+      return (
+        Math.ceil(currentRating * (1 / this.props.jumpValue)) /
+        (1 / this.props.jumpValue)
+      );
+    } else {
+      return currentRating;
+    }
   }
 
   setCurrentRating(rating) {
@@ -241,7 +267,7 @@ export default class SwipeRating extends Component {
       <View pointerEvents={readonly ? 'none' : 'auto'} style={style}>
         {showRating && this.displayCurrentRating()}
         <View style={styles.starsWrapper} {...this.state.panResponder.panHandlers}>
-          <View style={styles.starsInsideWrapper}>
+          <View style={styles.starsInsideWrapper} onLayout={(e) => {this.handleLayoutChange(e)}} ref={(view) => {this.ratingRef = view;}}>
             <Animated.View style={this.getPrimaryViewStyle()} />
             <Animated.View style={this.getSecondaryViewStyle()} />
           </View>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -93,9 +93,20 @@ export interface RatingProps {
   minValue?: number;
 
   /**
+   * The number to jump per swipe
+   * Default is 0 (not to jump)
+   */
+  jumpValue?: number;
+  
+  /**
    * Callback method when the user starts rating.
    */
-  onStartRating?(): void;
+  onStartRating?( rating: number): void;
+
+  /**
+   * Callback method when the user is swiping.
+   */
+  onSwipeRating?( rating: number): void;
 
   /**
    * Callback method when the user finishes rating. Gives you the final rating value as a whole number


### PR DESCRIPTION
### Hi, I found that SwipeRating doesn't work well in some cases.
### And I think I can solve these issues with my improvements: #118 #101 #83 #82 #56
--- 
## These are the issues I found and Solved:
### 1. Swiping
Swipe Rating always starts from the default starting value. The ratingValue is only affected by the gesture.dx. So the initial pressed position is needed to affect the ratingValue in **onPanResponderMove**.
### 2. Tapping
Tapping the panResponder only evaluates **onPanResponderGrant**. So the ratingValue and the ratingImage doesn't changes to the position that user pressed.

## And I added some customize options to props.
These are the props I added:
### 1. jumpValue : number (optional)
**jumpValue** makes the ratingValue possible to jump per the value.
For example, if the **jumpValue={0.5}**, the ratingValue will increase/decrease like 0 => 0.5 => 1.0 => 1.5 => 2.0 => 2.5...
else if the **jumpValue={0.2}**, the ratingValue will increase/decrease like 0 => 0.2 => 0.4 => 0.6 => 0.8 => 1.0...
Of course this can be done with **minValue**

### 2. onSwipeRating : ( rating : number) => void (optional)
**onSwipeRating** is a callback that  is evaluated with **onStartRating** , during swiping event and before **onFinishRating**. (when if **onPanResponderGrant** and **onPanResponderMove** is active)
This makes possible to get current value while swiping.
This can make user to using ratingValue to other component.

### 3 (new edit). onStartRating: ( rating: number ) => void
I add `rating` param to `onStartRating` callback, so that user can get the rating value at **tapping** event

## Here are the examples I captured
### 1. minValue={0.5} jumpValue={0.5} show rating in other component by onSwipeRating

https://user-images.githubusercontent.com/65849802/110312497-7bec0c80-8048-11eb-8f32-c8622b8a1629.mov

As you can see, swipe starts at the point that user pressed (1-1), tapping the star works fine (1-2), ratingValues are jumps per the **jumpValue** (2-1), and my information component is showing the ratingValue in real time (2-2).

### 2. minValue={0.5} show rating in other component by onSwipeRating

https://user-images.githubusercontent.com/65849802/110312707-c9687980-8048-11eb-880e-479e07fe3b75.mov

you can use without the **jumpValue** props (optional)

This is the first time for sending pull request. 😅 So let me know if you have any feedback or message. I'll edit READ.me as soon as you accept my pull request! Thank you!!