### PR TITLE
Bugfix/fix assests issue

### DIFF
--- a/demo/src/SwipeRatingScreen.tsx
+++ b/demo/src/SwipeRatingScreen.tsx
@@ -8,7 +8,7 @@ import {
   StyleSheet,
   StatusBar
 } from "react-native";
-import { Rating } from "../../src/index";
+import { Rating } from "../../dist/index";
 
 import Card from "./Card";
 

--- a/demo/src/TapRatingScreen.tsx
+++ b/demo/src/TapRatingScreen.tsx
@@ -8,7 +8,7 @@ import {
   StyleSheet,
   StatusBar
 } from "react-native";
-import { AirbnbRating } from "../../src/index";
+import { AirbnbRating } from "../../dist/index";
 
 import Card from "./Card";
 const WATER_IMAGE = require( "../assets/water.png" );

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "lint-all": "yarn lint && yarn lint-demo",
     "clean-install": "rm -rf node_modules && yarn",
     "prepare": "husky install",
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "copy-files": "cp -R ./src/images ./dist/images/",
+    "postbuild": "yarn run copy-files"
   },
   "author": "Monte Thakkar",
   "license": "MIT",


### PR DESCRIPTION
Fixes #145 

- Updates expo app to use built files instead of the typescript ones
- Adds post build script to copy assets

With the first commit - the error is reproduced:

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-04-14 at 13 35 23](https://user-images.githubusercontent.com/10060786/114675878-5d072700-9d26-11eb-8fdd-705c650386ab.png)
