### PR TITLE
Replace defaultProps with default parameters to avoid React 18 warning

### DIFF
--- a/src/SwipeRating.tsx
+++ b/src/SwipeRating.tsx
@@ -196,22 +196,20 @@ export default class SwipeRating extends Component<
   SwipeRatingProps,
   SwipeRatingState
 > {
+  static defaultProps = {
+    type: "star",
+    ratingImage: STAR_IMAGE,
+    ratingColor: "#f1c40f",
+    ratingBackgroundColor: "white",
+    ratingCount: 5,
+    showReadOnlyText: true,
+    imageSize: 40,
+    minValue: 0,
+    jumpValue: 0,
+  };
   ratingRef: any;
 
-  constructor(overrideProps) {
-    const props = {
-      type: "star",
-      ratingImage: STAR_IMAGE,
-      ratingColor: "#f1c40f",
-      ratingBackgroundColor: "white",
-      ratingCount: 5,
-      showReadOnlyText: true,
-      imageSize: 40,
-      minValue: 0,
-      jumpValue: 0,
-      ...overrideProps
-    }
-
+  constructor(props) {
     super(props);
     const { onStartRating, onSwipeRating, onFinishRating, fractions } =
       this.props;

--- a/src/SwipeRating.tsx
+++ b/src/SwipeRating.tsx
@@ -196,20 +196,22 @@ export default class SwipeRating extends Component<
   SwipeRatingProps,
   SwipeRatingState
 > {
-  static defaultProps = {
-    type: "star",
-    ratingImage: STAR_IMAGE,
-    ratingColor: "#f1c40f",
-    ratingBackgroundColor: "white",
-    ratingCount: 5,
-    showReadOnlyText: true,
-    imageSize: 40,
-    minValue: 0,
-    jumpValue: 0,
-  };
   ratingRef: any;
 
-  constructor(props) {
+  constructor(overrideProps) {
+    const props = {
+      type: "star",
+      ratingImage: STAR_IMAGE,
+      ratingColor: "#f1c40f",
+      ratingBackgroundColor: "white",
+      ratingCount: 5,
+      showReadOnlyText: true,
+      imageSize: 40,
+      minValue: 0,
+      jumpValue: 0,
+      ...overrideProps
+    }
+
     super(props);
     const { onStartRating, onSwipeRating, onFinishRating, fractions } =
       this.props;

--- a/src/TapRating.tsx
+++ b/src/TapRating.tsx
@@ -109,18 +109,26 @@ export type TapRatingProps = {
   starStyle?: StyleProp<ViewStyle>;
 };
 
-const TapRating: React.FunctionComponent<TapRatingProps> = (props) => {
-  const [position, setPosition] = useState<number>(props.defaultRating);
+const TapRating: React.FunctionComponent<TapRatingProps> =
+    ({
+         defaultRating = 3,
+         reviews = ["Terrible", "Bad", "Okay", "Good", "Great"],
+         count = 5,
+         showRating = true,
+         reviewColor = "rgba(230, 196, 46, 1)",
+         reviewSize = 25,
+         ...props
+     }) => {
+  const [position, setPosition] = useState<number>(defaultRating);
 
   useEffect(() => {
-    const { defaultRating } = props;
 
     if (defaultRating === null || defaultRating === undefined) {
       setPosition(3);
     } else {
       setPosition(defaultRating);
     }
-  }, [props.defaultRating]);
+  }, [defaultRating]);
 
   const renderStars = (rating_array) => {
     return _.map(rating_array, (star) => {
@@ -138,7 +146,6 @@ const TapRating: React.FunctionComponent<TapRatingProps> = (props) => {
     setPosition(position);
   };
 
-  const { count, reviews, showRating, reviewColor, reviewSize } = props;
   const rating_array = [];
   const starContainerStyle = [styles.starContainer];
 
@@ -181,15 +188,6 @@ const TapRating: React.FunctionComponent<TapRatingProps> = (props) => {
       <View style={starContainerStyle}>{renderStars(rating_array)}</View>
     </View>
   );
-};
-
-TapRating.defaultProps = {
-  defaultRating: 3,
-  reviews: ["Terrible", "Bad", "Okay", "Good", "Great"],
-  count: 5,
-  showRating: true,
-  reviewColor: "rgba(230, 196, 46, 1)",
-  reviewSize: 25,
 };
 
 const styles = StyleSheet.create({

--- a/src/components/Star.tsx
+++ b/src/components/Star.tsx
@@ -23,7 +23,7 @@ export type StarProps = {
   starSelectedInPosition?: ( number ) => void;
 };
 
-const Star: React.FunctionComponent<StarProps> = props => {
+const Star: React.FunctionComponent<StarProps> = ({starImage = STAR_IMAGE, selectedColor = "#f1c40f", unSelectedColor = "#BDC3C7", ...props}) => {
   const [selected, setSelected] = useState<boolean>( false );
   const springValue = new Animated.Value( 1 );
 
@@ -45,11 +45,8 @@ const Star: React.FunctionComponent<StarProps> = props => {
   };
 
   const {
-    starImage,
     fill,
     size,
-    selectedColor,
-    unSelectedColor,
     isDisabled,
     starStyle
   } = props;

--- a/src/components/Star.tsx
+++ b/src/components/Star.tsx
@@ -73,12 +73,6 @@ const Star: React.FunctionComponent<StarProps> = ({starImage = STAR_IMAGE, selec
   );
 };
 
-Star.defaultProps = {
-  starImage: STAR_IMAGE,
-  selectedColor: "#f1c40f",
-  unSelectedColor: "#BDC3C7"
-};
-
 export default Star;
 
 const styles = StyleSheet.create( {


### PR DESCRIPTION
When using `react-native-ratings` with React 18, the following warning appears:

"Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead."

This set of changes removes the usage of `defaultProps`, and replaces it with default parameters, avoiding the warning and protecting against future releases of React removing support for `defaultProps`